### PR TITLE
Fixes undefined behaviors in the form of writes to unallocated memory locations

### DIFF
--- a/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
@@ -1067,6 +1067,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
@@ -1067,6 +1067,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
@@ -1067,6 +1067,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
@@ -1068,6 +1068,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
@@ -1067,6 +1067,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
@@ -1067,6 +1067,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
@@ -1067,6 +1067,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
@@ -1067,6 +1067,8 @@ int main(void)
   {
   {
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
   ssl3_connect(s);
   }

--- a/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 8464;
   tmp = ssl3_accept(s);
   }

--- a/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 8464;
   tmp = ssl3_accept(s);
   }

--- a/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 8464;
   tmp = ssl3_accept(s);
   }

--- a/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 8464;
   tmp = ssl3_accept(s);
   }

--- a/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 8464;
   tmp = ssl3_accept(s);
   }

--- a/c/ssh/s3_srvr.blast.03_true-unreach-call.i.cil.c.trace
+++ b/c/ssh/s3_srvr.blast.03_true-unreach-call.i.cil.c.trace
@@ -13,6 +13,7 @@ main()
     ...
     s = malloc(sizeof(SSL));                        // s = 0x7fffff08
     s->s3 = malloc(sizeof(struct ssl3_state_st));   // s->s3 = 0x7ffff780 (stored @0x7fffff5c)
+    s->session = malloc(sizeof(SSL_SESSION));
     s->state = 8464;
     tmp = ssl3_accept(s);  // *** 1 ***
     ...

--- a/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   s->state = 8464;
   tmp = ssl3_accept(s);
   }

--- a/c/ssh/s3_srvr.blast.04_true-unreach-call.i.cil.c.trace
+++ b/c/ssh/s3_srvr.blast.04_true-unreach-call.i.cil.c.trace
@@ -13,6 +13,7 @@ main()
     ...
     s = malloc(sizeof(SSL));                        // s = 0x7fffff08
     s->s3 = malloc(sizeof(struct ssl3_state_st));   // s->s3 = 0x7ffff780 (stored @ 0x7fffff5c)
+    s->session = malloc(sizeof(SSL_SESSION));
     s->state = 8464;
     tmp = ssl3_accept(s);                           // *** 1 ***
     ...

--- a/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);

--- a/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
@@ -1074,6 +1074,8 @@ int main(void)
   {
   s = malloc(sizeof(SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
+  s->session = malloc(sizeof(SSL_SESSION));
   tmp = ssl3_accept(s);
   }
   return (tmp);


### PR DESCRIPTION
Structures at fields `s->ctx` and `s->session` are being written to, and yet those structures are not allocated, which is undefined behavior. Our fix allocates those structures appropriately.