### PR TITLE
fixes for some undefined behaviors for pthread examples

### DIFF
--- a/c/pthread-atomic/qrcu_false-unreach-call.c
+++ b/c/pthread-atomic/qrcu_false-unreach-call.c
@@ -116,7 +116,7 @@ void *qrcu_reader2() {
 
 void* qrcu_updater() {
   int i;
-  int readerstart1, readerstart2;
+  int readerstart1=__VERIFIER_nondet_int(), readerstart2=__VERIFIER_nondet_int();
   int sum;
   __VERIFIER_atomic_take_snapshot(readerstart1, readerstart2);
   sum_unordered;

--- a/c/pthread-atomic/qrcu_false-unreach-call.i
+++ b/c/pthread-atomic/qrcu_false-unreach-call.i
@@ -706,7 +706,7 @@ void *qrcu_reader2() {
 }
 void* qrcu_updater() {
   int i;
-  int readerstart1, readerstart2;
+  int readerstart1=__VERIFIER_nondet_int(), readerstart2=__VERIFIER_nondet_int();
   int sum;
   __VERIFIER_atomic_take_snapshot(readerstart1, readerstart2);
   if (__VERIFIER_nondet_int()) { sum = ctr1; sum = sum + ctr2; } else { sum = ctr2; sum = sum + ctr1; };

--- a/c/pthread-atomic/scull_true-unreach-call.c
+++ b/c/pthread-atomic/scull_true-unreach-call.c
@@ -360,12 +360,12 @@ inline int scull_init_module()
 /* =====================================================
    User program calling functions from the device driver
    ===================================================== */
-void *loader() {
+void *loader(void *arg) {
   scull_init_module();
   scull_cleanup_module();
 }
 
-void *thread1() {
+void *thread1(void *arg) {
   file filp;
   char buf;
   size_t count = 10;
@@ -375,7 +375,7 @@ void *thread1() {
   scull_release(i, filp);
 }
 
-void *thread2() {
+void *thread2(void *arg) {
   file filp;
   char buf;
   size_t count = 10;

--- a/c/pthread-atomic/scull_true-unreach-call.i
+++ b/c/pthread-atomic/scull_true-unreach-call.i
@@ -847,11 +847,11 @@ inline int scull_init_module()
   scull_cleanup_module();
   return result;
 }
-void *loader() {
+void *loader(void *arg) {
   scull_init_module();
   scull_cleanup_module();
 }
-void *thread1() {
+void *thread1(void *arg) {
   int filp;
   int buf;
   int count = 10;
@@ -860,7 +860,7 @@ void *thread1() {
   scull_read(1, filp, buf, count, off);
   0;
 }
-void *thread2() {
+void *thread2(void *arg) {
   int filp;
   int buf;
   int count = 10;

--- a/c/pthread/sigma_false-unreach-call.c
+++ b/c/pthread/sigma_false-unreach-call.c
@@ -9,7 +9,7 @@ void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_er
 const int SIGMA = 16;
 
 int *array;
-int array_index;
+int array_index=-1;
 
 
 void *thread(void * arg)
@@ -31,8 +31,8 @@ int main()
 	__VERIFIER_assume(array);
 
 	for (tid=0; tid<SIGMA; tid++) {
+	        array_index++;
 		pthread_create(&t[tid], 0, thread, 0);
-		array_index++;
 	}
 
 	for (tid=0; tid<SIGMA; tid++) {

--- a/c/pthread/sigma_false-unreach-call.i
+++ b/c/pthread/sigma_false-unreach-call.i
@@ -1212,7 +1212,7 @@ extern char *stpncpy (char *__restrict __dest,
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error();}; return; }
 const int SIGMA = 16;
 int *array;
-int array_index;
+int array_index=-1;
 void *thread(void * arg)
 {
  array[array_index] = 1;
@@ -1227,8 +1227,8 @@ int main()
  __VERIFIER_assume(t);
  __VERIFIER_assume(array);
  for (tid=0; tid<SIGMA; tid++) {
-  pthread_create(&t[tid], 0, thread, 0);
   array_index++;
+  pthread_create(&t[tid], 0, thread, 0);
  }
  for (tid=0; tid<SIGMA; tid++) {
   pthread_join(t[tid], 0);


### PR DESCRIPTION
fixes for some undefined behaviors for pthread examples, including uninitialized variables, function definitions of thread routines missing parameter list, array index out-of-bound.