### PR TITLE
Some uses of uninitialized variables in loops category

### DIFF
--- a/c/loop-invgen/id_build_true-unreach-call.i
+++ b/c/loop-invgen/id_build_true-unreach-call.i
@@ -10,6 +10,7 @@ int __VERIFIER_nondet_int();
 void main() {
   int offset, length, nlen;
   int i, j;
+  nlen = __VERIFIER_nondet_int();
   for (i=0; i<nlen; i++) {
     for (j=0; j<8; j++) {
       __VERIFIER_assert(0 <= nlen-1-i);

--- a/c/loop-invgen/sendmail-close-angle_true-unreach-call.i
+++ b/c/loop-invgen/sendmail-close-angle_true-unreach-call.i
@@ -14,6 +14,10 @@ int main ()
   int bufferlen;
   int buf;
   int buflim;
+
+  bufferlen = __VERIFIER_nondet_int();
+  inlen = __VERIFIER_nondet_int();
+
   if(bufferlen >1);else goto END;
   if(inlen > 0);else goto END;
   if(bufferlen < inlen);else goto END;


### PR DESCRIPTION
In a couple of benchmarks in the loops category there are some uninitialized variables. The fix initializes them before they are used.