### PR TITLE
Fixed declaration of __VERIFIER_assume

### DIFF
--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.1.ufo.BOUNDED-10.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_1.ufo.BOUNDED-10.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_1.ufo.UNBOUNDED.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_2.ufo.BOUNDED-10.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.4_2.ufo.UNBOUNDED.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.5.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.5.ufo.BOUNDED-10.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.5.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_false-unreach-call.5.ufo.UNBOUNDED.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_true-unreach-call.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_true-unreach-call.ufo.BOUNDED-10.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -98,7 +98,7 @@ _Bool side2Failed  ;
 msg_t side1_written  ;
 msg_t side2_written  ;
 void assert(_Bool arg ) ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 static _Bool side1Failed_History_0  ;
 static _Bool side1Failed_History_1  ;
 static _Bool side1Failed_History_2  ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.1.ufo.BOUNDED-10.pals.c
@@ -77,7 +77,7 @@ int8_t g3v_old ;
 int8_t g3v_new ;
 extern _Bool __VERIFIER_nondet_bool() ;
 extern msg_t __VERIFIER_nondet_int8_t() ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 _Bool gate1Failed  ;
 _Bool gate2Failed  ;
 _Bool gate3Failed  ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -77,7 +77,7 @@ int8_t g3v_old ;
 int8_t g3v_new ;
 extern _Bool __VERIFIER_nondet_bool() ;
 extern msg_t __VERIFIER_nondet_int8_t() ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 _Bool gate1Failed  ;
 _Bool gate2Failed  ;
 _Bool gate3Failed  ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.2.ufo.BOUNDED-10.pals.c
@@ -77,7 +77,7 @@ int8_t g3v_old ;
 int8_t g3v_new ;
 extern _Bool __VERIFIER_nondet_bool() ;
 extern msg_t __VERIFIER_nondet_int8_t() ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 _Bool gate1Failed  ;
 _Bool gate2Failed  ;
 _Bool gate3Failed  ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -77,7 +77,7 @@ int8_t g3v_old ;
 int8_t g3v_new ;
 extern _Bool __VERIFIER_nondet_bool() ;
 extern msg_t __VERIFIER_nondet_int8_t() ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 _Bool gate1Failed  ;
 _Bool gate2Failed  ;
 _Bool gate3Failed  ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated_true-unreach-call.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated_true-unreach-call.ufo.BOUNDED-10.pals.c
@@ -77,7 +77,7 @@ int8_t g3v_old ;
 int8_t g3v_new ;
 extern _Bool __VERIFIER_nondet_bool() ;
 extern msg_t __VERIFIER_nondet_int8_t() ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 _Bool gate1Failed  ;
 _Bool gate2Failed  ;
 _Bool gate3Failed  ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -77,7 +77,7 @@ int8_t g3v_old ;
 int8_t g3v_new ;
 extern _Bool __VERIFIER_nondet_bool() ;
 extern msg_t __VERIFIER_nondet_int8_t() ;
-extern void __VERIFIER_assume(_Bool arg ) ;
+extern void __VERIFIER_assume(int arg ) ;
 _Bool gate1Failed  ;
 _Bool gate2Failed  ;
 _Bool gate3Failed  ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.BOUNDED-6.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.BOUNDED-6.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.BOUNDED-8.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.BOUNDED-8.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.BOUNDED-10.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.BOUNDED-10.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.BOUNDED-12.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.BOUNDED-12.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.BOUNDED-12.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.BOUNDED-6.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.BOUNDED-8.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.BOUNDED-10.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.BOUNDED-12.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.BOUNDED-12.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.BOUNDED-14.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.BOUNDED-14.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.BOUNDED-14.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.BOUNDED-14.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.BOUNDED-16.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.BOUNDED-16.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.8_true-unreach-call.ufo.BOUNDED-16.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_true-unreach-call.ufo.BOUNDED-16.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_lcr.8_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -62,7 +62,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 char __VERIFIER_nondet_msg_t(void) ;
 char __VERIFIER_nondet_char(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.3.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.BOUNDED-6.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.BOUNDED-8.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_true-unreach-call.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_true-unreach-call.ufo.BOUNDED-10.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,7 +61,7 @@ DM-0000575
 char __VERIFIER_nondet_char(void) ;
 _Bool __VERIFIER_nondet__Bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
@@ -92,7 +92,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
@@ -97,7 +97,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
@@ -102,7 +102,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
@@ -112,7 +112,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
@@ -92,7 +92,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
@@ -97,7 +97,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
@@ -81,7 +81,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
@@ -81,7 +81,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
@@ -91,7 +91,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
@@ -96,7 +96,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
@@ -81,7 +81,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
@@ -81,7 +81,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
@@ -91,7 +91,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
@@ -96,7 +96,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
@@ -91,7 +91,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
@@ -96,7 +96,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<startrek builtins>"
 unsigned char __startrek_task  ;
 #line 1 "<startrek builtins>"

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
@@ -86,7 +86,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M4.c
@@ -86,7 +86,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
@@ -94,7 +94,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M4.c
@@ -94,7 +94,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
@@ -86,7 +86,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M4.c
@@ -86,7 +86,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
@@ -77,7 +77,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M4.c
@@ -77,7 +77,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
@@ -85,7 +85,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M4.c
@@ -85,7 +85,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
@@ -77,7 +77,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M4.c
@@ -77,7 +77,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
@@ -85,7 +85,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M4.c
@@ -85,7 +85,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
@@ -85,7 +85,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M4.c
@@ -85,7 +85,7 @@ _Bool __VERIFIER_nondet__Bool(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 extern int __VERIFIER_nondet_int();
-void __VERIFIER_assume(_Bool arg ) ;
+void __VERIFIER_assume(int arg ) ;
 #line 1 "<compiler builtins>"
 unsigned char __startrek_round  ;
 #line 1 "<compiler builtins>"


### PR DESCRIPTION
Based on the SVCOMP rules, __VERIFIER_assume should take int as
its argument and not _Bool.