### PR TITLE
fixed uninitialized variables using nondet_int function calls

### DIFF
--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
@@ -74,6 +74,8 @@ OUTPUT a
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern unsigned int __VERIFIER_nondet_uint();
+
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -139,7 +141,7 @@ unsigned start(unsigned a_in, unsigned b_in)
 
 void check_gcd(unsigned a_in, unsigned b_in, unsigned gcd)
 {
-  unsigned guessed_gcd;
+  unsigned guessed_gcd=__VERIFIER_nondet_uint();
   __VERIFIER_assume(a_in%guessed_gcd==0);
   __VERIFIER_assume(b_in%guessed_gcd==0);
   __VERIFIER_assume(guessed_gcd>1);
@@ -153,14 +155,11 @@ void check_gcd(unsigned a_in, unsigned b_in, unsigned gcd)
 int main()
 {
   // for testing with small unwinding bounds
-  unsigned a_in; //=8;
-  unsigned b_in; //=6;
+  unsigned a_in=__VERIFIER_nondet_uint(); //=8;
+  unsigned b_in=__VERIFIER_nondet_uint(); //=6;
 
   __VERIFIER_assume(a_in>0);
   __VERIFIER_assume(b_in>0);
-
   check_gcd(a_in, b_in, start(a_in, b_in));
-
   return 0;
 }
-

--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
@@ -14,6 +14,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
+extern unsigned int __VERIFIER_nondet_uint();
+
 # 1 "/usr/include/pthread.h" 1 3 4
 # 21 "/usr/include/pthread.h" 3 4
 # 1 "/usr/include/features.h" 1 3 4
@@ -1427,7 +1429,7 @@ unsigned start(unsigned a_in, unsigned b_in)
 
 void check_gcd(unsigned a_in, unsigned b_in, unsigned gcd)
 {
-  unsigned guessed_gcd;
+  unsigned guessed_gcd=__VERIFIER_nondet_uint();
   __VERIFIER_assume(a_in%guessed_gcd==0);
   __VERIFIER_assume(b_in%guessed_gcd==0);
   __VERIFIER_assume(guessed_gcd>1);
@@ -1441,8 +1443,8 @@ void check_gcd(unsigned a_in, unsigned b_in, unsigned gcd)
 int main()
 {
 
-  unsigned a_in;
-  unsigned b_in;
+  unsigned a_in=__VERIFIER_nondet_uint();
+  unsigned b_in=__VERIFIER_nondet_uint();
 
   __VERIFIER_assume(a_in>0);
   __VERIFIER_assume(b_in>0);

--- a/c/pthread-ext/09_fmaxsym_true-unreach-call.c
+++ b/c/pthread-ext/09_fmaxsym_true-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 #include <pthread.h>
 
@@ -43,7 +44,7 @@ inline void findMax(int offset)
 }
 
 void* thr1(void* arg) {
-	int offset;
+	int offset=__VERIFIER_nondet_int();
 
 	assume(offset % WORKPERTHREAD == 0 && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);
 	//assume(offset < WORKPERTHREAD && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);

--- a/c/pthread-ext/09_fmaxsym_true-unreach-call.i
+++ b/c/pthread-ext/09_fmaxsym_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
@@ -661,7 +662,7 @@ inline void findMax(int offset)
  }
 }
 void* thr1(void* arg) {
- int offset;
+  int offset=__VERIFIER_nondet_int();
  __VERIFIER_assume(offset % 2 == 0 && offset >= 0 && offset < 2*3);
  findMax(offset);
   return 0;

--- a/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.c
+++ b/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 #include <pthread.h>
 
@@ -53,7 +54,7 @@ inline void findMax(int offset){
 }
 
 void* thr1(void* arg) {
-	int offset;
+	int offset=__VERIFIER_nondet_int();
 
 	assume(offset % WORKPERTHREAD == 0 && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);
 	//assume(offset < WORKPERTHREAD && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);

--- a/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.i
+++ b/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
@@ -671,7 +672,7 @@ inline void findMax(int offset){
  }
 }
 void* thr1(void* arg) {
- int offset;
+ int offset=__VERIFIER_nondet_int();
  __VERIFIER_assume(offset % 2 == 0 && offset >= 0 && offset < 2*3);
  findMax(offset);
   return 0;

--- a/c/pthread-ext/11_fmaxsymopt_true-unreach-call.c
+++ b/c/pthread-ext/11_fmaxsymopt_true-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 #include <pthread.h>
 
@@ -55,7 +56,7 @@ inline void findMax(int offset){
 }
 
 void* thr1(void* arg) {
-	int offset;
+	int offset=__VERIFIER_nondet_int();
 
 	assume(offset % WORKPERTHREAD == 0 && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);
 	//assume(offset < WORKPERTHREAD && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);

--- a/c/pthread-ext/11_fmaxsymopt_true-unreach-call.i
+++ b/c/pthread-ext/11_fmaxsymopt_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
@@ -665,7 +666,7 @@ inline void findMax(int offset){
  { if(!(my_max <= max)) { ERROR: __VERIFIER_error();(void)0; } };
 }
 void* thr1(void* arg) {
- int offset;
+ int offset=__VERIFIER_nondet_int();
  __VERIFIER_assume(offset % 2 == 0 && offset >= 0 && offset < 2*3);
  findMax(offset);
   return 0;

--- a/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.c
+++ b/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 #include <pthread.h>
 
@@ -59,7 +60,7 @@ inline void findMax(int offset){
 }
 
 void* thr1(void* arg) {
-	int offset;
+	int offset=__VERIFIER_nondet_int();
 
 	assume(offset % WORKPERTHREAD == 0 && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);
 	//assume(offset < WORKPERTHREAD && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);

--- a/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.i
+++ b/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
@@ -676,7 +677,7 @@ inline void findMax(int offset){
  { if(!(my_max <= max)) { ERROR: __VERIFIER_error();(void)0; } };
 }
 void* thr1(void* arg) {
- int offset;
+ int offset=__VERIFIER_nondet_int();
  __VERIFIER_assume(offset % 2 == 0 && offset >= 0 && offset < 2*3);
  findMax(offset);
   return 0;

--- a/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.c
+++ b/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern unsigned int __VERIFIER_nondet_uint();
 
 #include <pthread.h>
 
@@ -6,7 +7,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 #define assert(e) { if(!(e)) { ERROR: __VERIFIER_error();(void)0; } }
 
 void* thr1(void* arg){
-  unsigned int x, y, z;
+  unsigned int x=__VERIFIER_nondet_uint(), y=__VERIFIER_nondet_uint(), z=__VERIFIER_nondet_uint();
   int i, j, k;
   for(i=0; i<x; i++) {
     for(j=i+1; j<y; j++) {

--- a/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.i
+++ b/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern unsigned int __VERIFIER_nondet_uint();
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
@@ -633,7 +634,7 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
 void* thr1(void* arg){
-  unsigned int x, y, z;
+  unsigned int x=__VERIFIER_nondet_uint(), y=__VERIFIER_nondet_uint(), z=__VERIFIER_nondet_uint();
   int i, j, k;
   for(i=0; i<x; i++) {
     for(j=i+1; j<y; j++) {


### PR DESCRIPTION
fixed uninitialized variables using __VERIFIER_nondet_int(uint) function calls.