### PR TITLE
fixed modulus denominator possibly being zero.

### DIFF
--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
@@ -142,9 +142,9 @@ unsigned start(unsigned a_in, unsigned b_in)
 void check_gcd(unsigned a_in, unsigned b_in, unsigned gcd)
 {
   unsigned guessed_gcd=__VERIFIER_nondet_uint();
+  __VERIFIER_assume(guessed_gcd>1);
   __VERIFIER_assume(a_in%guessed_gcd==0);
   __VERIFIER_assume(b_in%guessed_gcd==0);
-  __VERIFIER_assume(guessed_gcd>1);
 
   __VERIFIER_assert(a_in%gcd==0);
   __VERIFIER_assert(b_in%gcd==0);

--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
@@ -1430,9 +1430,9 @@ unsigned start(unsigned a_in, unsigned b_in)
 void check_gcd(unsigned a_in, unsigned b_in, unsigned gcd)
 {
   unsigned guessed_gcd=__VERIFIER_nondet_uint();
+  __VERIFIER_assume(guessed_gcd>1);
   __VERIFIER_assume(a_in%guessed_gcd==0);
   __VERIFIER_assume(b_in%guessed_gcd==0);
-  __VERIFIER_assume(guessed_gcd>1);
 
   __VERIFIER_assert(a_in%gcd==0);
   __VERIFIER_assert(b_in%gcd==0);


### PR DESCRIPTION
move the assumption that guessed_gcd>1 so that the modulus denominator could never be zero.