### PR TITLE
Fix mismatched argument type in isdn drivers. GCC 5.2.0 emitted

### DIFF
--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.08_1a.cil_true-unreach-call.i
@@ -4518,7 +4518,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.32_7a.cil_true-unreach-call.i
@@ -4534,7 +4534,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.39_7a.cil_true-unreach-call.i
@@ -4621,7 +4621,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.43_1a.cil_true-unreach-call.i
@@ -4555,7 +4555,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_001.c5b61d5.68_1.cil_true-unreach-call.i
@@ -6303,7 +6303,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.08_1a.cil_true-unreach-call.i
@@ -4534,7 +4534,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.32_1.cil_true-unreach-call.i
@@ -5982,7 +5982,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.32_7a.cil_true-unreach-call.i
@@ -4550,7 +4550,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.39_7a.cil_true-unreach-call.i
@@ -4645,7 +4645,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.43_1a.cil_true-unreach-call.i
@@ -4571,7 +4571,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_002.ff4cc1d.68_1.cil_true-unreach-call.i
@@ -6333,7 +6333,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.08_1a.cil_true-unreach-call.i
@@ -4538,7 +4538,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.32_1.cil_true-unreach-call.i
@@ -5984,7 +5984,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.32_7a.cil_true-unreach-call.i
@@ -4554,7 +4554,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.39_7a.cil_true-unreach-call.i
@@ -4649,7 +4649,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.43_1a.cil_true-unreach-call.i
@@ -4575,7 +4575,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_003.ce425a9.68_1.cil_true-unreach-call.i
@@ -6338,7 +6338,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.08_1a.cil_true-unreach-call.i
@@ -4595,7 +4595,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.32_1.cil_true-unreach-call.i
@@ -6096,7 +6096,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.32_7a.cil_true-unreach-call.i
@@ -4611,7 +4611,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.39_7a.cil_true-unreach-call.i
@@ -4706,7 +4706,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.43_1a.cil_true-unreach-call.i
@@ -4632,7 +4632,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72

--- a/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--isdn--mISDN--mISDN_core.ko_004.6bff338.68_1.cil_true-unreach-call.i
@@ -6450,7 +6450,7 @@ struct Bprotocol *get_Bprotocol4mask(u_int m ) ;
 #line 67
 struct Bprotocol *get_Bprotocol4id(u_int id ) ;
 #line 69
-extern int mISDN_inittimer(u_int * ) ;
+extern int mISDN_inittimer(int * ) ;
 #line 70
 void mISDN_timer_cleanup(void) ;
 #line 72


### PR DESCRIPTION
errors without this fix.