### PR TITLE
fixed uninitialized variables

### DIFF
--- a/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.c
+++ b/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.c
@@ -8,7 +8,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 
 void* thr1(void* arg){
   unsigned int x=__VERIFIER_nondet_uint(), y=__VERIFIER_nondet_uint(), z=__VERIFIER_nondet_uint();
-  int i, j, k;
+  int i, j=1, k=1;
   for(i=0; i<x; i++) {
     for(j=i+1; j<y; j++) {
       for(k = j; k < z; k++) {

--- a/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.i
+++ b/c/pthread-ext/28_buggy_simple_loop1_vf_false-unreach-call.i
@@ -635,7 +635,7 @@ extern int pthread_atfork (void (*__prepare) (void),
 
 void* thr1(void* arg){
   unsigned int x=__VERIFIER_nondet_uint(), y=__VERIFIER_nondet_uint(), z=__VERIFIER_nondet_uint();
-  int i, j, k;
+  int i, j=1, k=1;
   for(i=0; i<x; i++) {
     for(j=i+1; j<y; j++) {
       for(k = j; k < z; k++) {


### PR DESCRIPTION
When x equals to 0, j and k will never get initialized; therefore, initialized j and k to 1, as what would be done by the initializations in the nested for loops.