### PR TITLE
fixed the initialization of the variable t of type pthread_t

### DIFF
--- a/c/pthread-lit/fkp2014_true-unreach-call.c
+++ b/c/pthread-lit/fkp2014_true-unreach-call.c
@@ -25,7 +25,7 @@ void main() {
     pthread_t t;
     int i, n;
     s = 0;
-    t = 0;
+    //t = 0;
     n = __VERIFIER_nondet_int();
     __VERIFIER_assume(n > 0);
     for (i = 0; i < n; i++) {

--- a/c/pthread-lit/fkp2014_true-unreach-call.i
+++ b/c/pthread-lit/fkp2014_true-unreach-call.i
@@ -678,7 +678,7 @@ void main() {
     pthread_t t;
     int i, n;
     s = 0;
-    t = 0;
+    //t = 0;
     n = __VERIFIER_nondet_int();
     __VERIFIER_assume(n > 0);
     for (i = 0; i < n; i++) {


### PR DESCRIPTION
t=0; is unsafe because pthread_t is an opaque object and it could be defined as a struct in some implementation. Thus removed this assignment.