### PR TITLE
Fixed two clang compilation errors

### DIFF
--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1033,7 +1033,7 @@ long ldv__builtin_expect(long val , long res ) ;
 __inline static int fls(int x )  __attribute__((__no_instrument_function__)) ;
 #line 439 "/home/zakharov/launch/inst/current/envs/linux-3.4/linux-3.4/arch/x86/include/asm/bitops.h"
 __inline static int fls(int x ) 
-{ int r ;
+{ long r ;
   long tmp ;
 
   {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--doc2001plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--doc2001plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2581,7 +2581,7 @@ long ldv__builtin_expect(long val , long res ) ;
 __inline static int ffs(int x )  __attribute__((__no_instrument_function__)) ;
 #line 397 "/home/zakharov/launch/inst/current/envs/linux-3.4/linux-3.4/arch/x86/include/asm/bitops.h"
 __inline static int ffs(int x ) 
-{ int r ;
+{ long r ;
   long tmp ;
 
   {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--doc2001plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--doc2001plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2538,7 +2538,7 @@ void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;
 #line 397 "/home/zakharov/launch/inst/current/envs/linux-3.4/linux-3.4/arch/x86/include/asm/bitops.h"
 __inline static int ffs(int x ) 
-{ int r ;
+{ long r ;
   long tmp ;
 
   {


### PR DESCRIPTION
Inline asm was causing clang compilation errors in two benchmarks. These small fixes address this issue. Benchmarks can still be compiled on gcc too without any problems.