### PR TITLE
Left shift operator creates undefined behavior

### DIFF
--- a/c/array-examples/relax_true-unreach-call.c
+++ b/c/array-examples/relax_true-unreach-call.c
@@ -119,7 +119,7 @@ _Bool is_relaxed_prefix(
 
 int main()
 {
-  unsigned long pat_len /*=3*/, a_len /*=4*/;
+  unsigned long pat_len = __VERIFIER_nondet_ulong(), a_len = __VERIFIER_nondet_ulong();
 
   int *pat=malloc(sizeof(int)*pat_len);
   int *a=malloc(sizeof(int)*a_len);
@@ -131,7 +131,7 @@ int main()
   if(is_relaxed_prefix(pat, pat_len, a, a_len))
   {
     __VERIFIER_assert(pat_len<=a_len+1);
-    unsigned long different;
+    unsigned long different = __VERIFIER_nondet_ulong();
     if(pat_len>a_len)
       different=pat_len-1;
     for(int i=0; i<pat_len && i<a_len; i++)

--- a/c/array-examples/relax_true-unreach-call.i
+++ b/c/array-examples/relax_true-unreach-call.i
@@ -1244,7 +1244,7 @@ _Bool is_relaxed_prefix(
 
 int main()
 {
-  unsigned long pat_len , a_len ;
+  unsigned long pat_len = __VERIFIER_nondet_ulong(), a_len = __VERIFIER_nondet_ulong();
 
   int *pat=malloc(sizeof(int)*pat_len);
   int *a=malloc(sizeof(int)*a_len);
@@ -1256,7 +1256,7 @@ int main()
   if(is_relaxed_prefix(pat, pat_len, a, a_len))
   {
     __VERIFIER_assert(pat_len<=a_len+1);
-    unsigned long different;
+    unsigned long different = __VERIFIER_nondet_ulong();
     if(pat_len>a_len)
       different=pat_len-1;
     for(int i=0; i<pat_len && i<a_len; i++)

--- a/c/array-examples/standard_seq_init_true-unreach-call_ground.i
+++ b/c/array-examples/standard_seq_init_true-unreach-call_ground.i
@@ -10,7 +10,7 @@ int main( ) {
     i = i + 1;
   }
   int x;
-  for ( x = 0 ; x < 100000 ; x++ ) {
+  for ( x = 1 ; x < 100000 ; x++ ) {
     __VERIFIER_assert( a[x] >= a[x-1] );
   }
   return 0;

--- a/c/bitvector/interleave_bits_true-unreach-call.i
+++ b/c/bitvector/interleave_bits_true-unreach-call.i
@@ -27,7 +27,7 @@ int main()
     unsigned int zz;
     unsigned int z = 0;
     unsigned int i = 0;
-    while (i < 32U) {
+    while (i < sizeof(x) * 8) {
         z |= ((x & (1U << i)) << i) | ((y & (1U << i)) << (i + 1));
         i += 1U;
     }

--- a/c/bitvector/modulus_true-unreach-call.i
+++ b/c/bitvector/modulus_true-unreach-call.i
@@ -24,6 +24,7 @@ int main()
     unsigned int s = __VERIFIER_nondet_uint();
     unsigned int d;
     unsigned int m;
+    __VERIFIER_assume(s < 32);
     d = (1 << s) - 1;
     if (d > 0) {
         m = n;


### PR DESCRIPTION
We added an assume statement that prevents undefined behavior in the left shift operator from happening. Note that left shift is undefined if one is shifting for >= the number of available bits.