### PR TITLE
fixed integer overflow by using unsigned integer

### DIFF
--- a/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.c
+++ b/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.c
@@ -38,7 +38,7 @@ void __VERIFIER_atomic_release()
 	MTX = 0;
 }
 
-volatile int refctr = 0;
+volatile unsigned int refctr = 0;
 
 inline static void put_client(int client){
 	mtx_lock(MTX);

--- a/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.i
+++ b/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.i
@@ -644,7 +644,7 @@ void __VERIFIER_atomic_release()
  __VERIFIER_assume(MTX==1);
  MTX = 0;
 }
-volatile int refctr = 0;
+volatile unsigned int refctr = 0;
 inline static void put_client(int client){
  __VERIFIER_atomic_acquire();{ if(!(MTX==1)) { goto ERROR; } };;
  --refctr;


### PR DESCRIPTION
It is possible that refctr gets incremented infinitely. Therefore, we need to change its type to unsigned int.