### PR TITLE
__VERIFIER_-functions are missing in many files. fixing it.

### DIFF
--- a/c/pthread-atomic/dekker_true-unreach-call.c
+++ b/c/pthread-atomic/dekker_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 /* Testcase from Threader's distribution. For details see:

--- a/c/pthread-atomic/dekker_true-unreach-call.i
+++ b/c/pthread-atomic/dekker_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
@@ -1,3 +1,6 @@
+extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
+extern void __VERIFIER_assume(int);
 // Copyright (c) 2015 Michael Tautschnig <michael.tautschnig@qmul.ac.uk>
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +75,6 @@ OD;
 OUTPUT a
 */
 
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 extern unsigned int __VERIFIER_nondet_uint();
 

--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.c
@@ -1,5 +1,4 @@
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
-void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
 extern void __VERIFIER_assume(int);
 // Copyright (c) 2015 Michael Tautschnig <michael.tautschnig@qmul.ac.uk>
 // 

--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
@@ -1,3 +1,6 @@
+extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
+extern void __VERIFIER_assume(int);
 # 1 "gcd_true-unreach-call_true-termination.c"
 # 1 "<built-in>"
 # 1 "<command-line>"
@@ -5,7 +8,6 @@
 # 1 "<command-line>" 2
 # 1 "gcd_true-unreach-call_true-termination.c"
 # 75 "gcd_true-unreach-call_true-termination.c"
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {

--- a/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
+++ b/c/pthread-atomic/gcd_true-unreach-call_true-termination.i
@@ -1,5 +1,4 @@
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
-void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
 extern void __VERIFIER_assume(int);
 # 1 "gcd_true-unreach-call_true-termination.c"
 # 1 "<built-in>"

--- a/c/pthread-atomic/qrcu_false-unreach-call.c
+++ b/c/pthread-atomic/qrcu_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 extern int __VERIFIER_nondet_int();

--- a/c/pthread-atomic/qrcu_false-unreach-call.i
+++ b/c/pthread-atomic/qrcu_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 extern int __VERIFIER_nondet_int();

--- a/c/pthread-atomic/qrcu_true-unreach-call.c
+++ b/c/pthread-atomic/qrcu_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 extern int __VERIFIER_nondet_int();

--- a/c/pthread-atomic/qrcu_true-unreach-call.i
+++ b/c/pthread-atomic/qrcu_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 extern int __VERIFIER_nondet_int();

--- a/c/pthread-atomic/read_write_lock_false-unreach-call.c
+++ b/c/pthread-atomic/read_write_lock_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 /* Testcase from Threader's distribution. For details see:

--- a/c/pthread-atomic/read_write_lock_false-unreach-call.i
+++ b/c/pthread-atomic/read_write_lock_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-atomic/read_write_lock_true-unreach-call.c
+++ b/c/pthread-atomic/read_write_lock_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 /* Testcase from Threader's distribution. For details see:

--- a/c/pthread-atomic/read_write_lock_true-unreach-call.i
+++ b/c/pthread-atomic/read_write_lock_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-atomic/time_var_mutex_true-unreach-call.c
+++ b/c/pthread-atomic/time_var_mutex_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 /* Testcase from Threader's distribution. For details see:

--- a/c/pthread-atomic/time_var_mutex_true-unreach-call.i
+++ b/c/pthread-atomic/time_var_mutex_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/01_inc_true-unreach-call.c
+++ b/c/pthread-ext/01_inc_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp04186/index.html

--- a/c/pthread-ext/01_inc_true-unreach-call.i
+++ b/c/pthread-ext/01_inc_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/03_incdec_true-unreach-call.c
+++ b/c/pthread-ext/03_incdec_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp04186/index.html

--- a/c/pthread-ext/03_incdec_true-unreach-call.i
+++ b/c/pthread-ext/03_incdec_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/04_incdec_cas_true-unreach-call.c
+++ b/c/pthread-ext/04_incdec_cas_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp04186/index.html

--- a/c/pthread-ext/04_incdec_cas_true-unreach-call.i
+++ b/c/pthread-ext/04_incdec_cas_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/06_ticket_true-unreach-call.c
+++ b/c/pthread-ext/06_ticket_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //Ticket lock with proportional backoff

--- a/c/pthread-ext/06_ticket_true-unreach-call.i
+++ b/c/pthread-ext/06_ticket_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/07_rand_true-unreach-call.c
+++ b/c/pthread-ext/07_rand_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp11234/

--- a/c/pthread-ext/07_rand_true-unreach-call.i
+++ b/c/pthread-ext/07_rand_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/08_rand_cas_true-unreach-call.c
+++ b/c/pthread-ext/08_rand_cas_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp11234/

--- a/c/pthread-ext/08_rand_cas_true-unreach-call.i
+++ b/c/pthread-ext/08_rand_cas_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/09_fmaxsym_true-unreach-call.c
+++ b/c/pthread-ext/09_fmaxsym_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/09_fmaxsym_true-unreach-call.i
+++ b/c/pthread-ext/09_fmaxsym_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.c
+++ b/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.i
+++ b/c/pthread-ext/10_fmaxsym_cas_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/11_fmaxsymopt_true-unreach-call.c
+++ b/c/pthread-ext/11_fmaxsymopt_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/11_fmaxsymopt_true-unreach-call.i
+++ b/c/pthread-ext/11_fmaxsymopt_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.c
+++ b/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.i
+++ b/c/pthread-ext/12_fmaxsymopt_cas_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int();
 

--- a/c/pthread-ext/13_unverif_true-unreach-call.c
+++ b/c/pthread-ext/13_unverif_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //Symmetry-Aware Predicate Abstraction for Shared-Variable Concurrent Programs (Extended Technical Report). CoRR abs/1102.2330 (2011)

--- a/c/pthread-ext/13_unverif_true-unreach-call.i
+++ b/c/pthread-ext/13_unverif_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/14_spin2003_true-unreach-call.c
+++ b/c/pthread-ext/14_spin2003_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/14_spin2003_true-unreach-call.i
+++ b/c/pthread-ext/14_spin2003_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/18_read_write_lock_true-unreach-call.c
+++ b/c/pthread-ext/18_read_write_lock_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/18_read_write_lock_true-unreach-call.i
+++ b/c/pthread-ext/18_read_write_lock_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/19_time_var_mutex_true-unreach-call.c
+++ b/c/pthread-ext/19_time_var_mutex_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/19_time_var_mutex_true-unreach-call.i
+++ b/c/pthread-ext/19_time_var_mutex_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/23_lu-fig2.fixed_true-unreach-call.c
+++ b/c/pthread-ext/23_lu-fig2.fixed_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/23_lu-fig2.fixed_true-unreach-call.i
+++ b/c/pthread-ext/23_lu-fig2.fixed_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/25_stack_longer_false-unreach-call.c
+++ b/c/pthread-ext/25_stack_longer_false-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/25_stack_longer_false-unreach-call.i
+++ b/c/pthread-ext/25_stack_longer_false-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/25_stack_longer_true-unreach-call.c
+++ b/c/pthread-ext/25_stack_longer_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/25_stack_longer_true-unreach-call.i
+++ b/c/pthread-ext/25_stack_longer_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/25_stack_longest_false-unreach-call.c
+++ b/c/pthread-ext/25_stack_longest_false-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/25_stack_longest_false-unreach-call.i
+++ b/c/pthread-ext/25_stack_longest_false-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/25_stack_longest_true-unreach-call.c
+++ b/c/pthread-ext/25_stack_longest_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/25_stack_longest_true-unreach-call.i
+++ b/c/pthread-ext/25_stack_longest_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/25_stack_true-unreach-call.c
+++ b/c/pthread-ext/25_stack_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //original file: EBStack.java

--- a/c/pthread-ext/25_stack_true-unreach-call.i
+++ b/c/pthread-ext/25_stack_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/26_stack_cas_longer_false-unreach-call.c
+++ b/c/pthread-ext/26_stack_cas_longer_false-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/26_stack_cas_longer_false-unreach-call.i
+++ b/c/pthread-ext/26_stack_cas_longer_false-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/26_stack_cas_longer_true-unreach-call.c
+++ b/c/pthread-ext/26_stack_cas_longer_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/26_stack_cas_longer_true-unreach-call.i
+++ b/c/pthread-ext/26_stack_cas_longer_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/26_stack_cas_longest_false-unreach-call.c
+++ b/c/pthread-ext/26_stack_cas_longest_false-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/26_stack_cas_longest_false-unreach-call.i
+++ b/c/pthread-ext/26_stack_cas_longest_false-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/26_stack_cas_longest_true-unreach-call.c
+++ b/c/pthread-ext/26_stack_cas_longest_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/26_stack_cas_longest_true-unreach-call.i
+++ b/c/pthread-ext/26_stack_cas_longest_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-ext/26_stack_cas_true-unreach-call.c
+++ b/c/pthread-ext/26_stack_cas_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //original file: EBStack.java

--- a/c/pthread-ext/26_stack_cas_true-unreach-call.i
+++ b/c/pthread-ext/26_stack_cas_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/27_Boop_simple_vf_false-unreach-call.c
+++ b/c/pthread-ext/27_Boop_simple_vf_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/27_Boop_simple_vf_false-unreach-call.i
+++ b/c/pthread-ext/27_Boop_simple_vf_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/29_conditionals_vs_true-unreach-call.c
+++ b/c/pthread-ext/29_conditionals_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/29_conditionals_vs_true-unreach-call.i
+++ b/c/pthread-ext/29_conditionals_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/30_Function_Pointer3_vs_true-unreach-call.c
+++ b/c/pthread-ext/30_Function_Pointer3_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/30_Function_Pointer3_vs_true-unreach-call.i
+++ b/c/pthread-ext/30_Function_Pointer3_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/31_simple_loop5_vs_true-unreach-call.c
+++ b/c/pthread-ext/31_simple_loop5_vs_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/31_simple_loop5_vs_true-unreach-call.i
+++ b/c/pthread-ext/31_simple_loop5_vs_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/32_pthread5_vs_false-unreach-call.c
+++ b/c/pthread-ext/32_pthread5_vs_false-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/32_pthread5_vs_false-unreach-call.i
+++ b/c/pthread-ext/32_pthread5_vs_false-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/33_double_lock_p1_vs_true-unreach-call.c
+++ b/c/pthread-ext/33_double_lock_p1_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/33_double_lock_p1_vs_true-unreach-call.i
+++ b/c/pthread-ext/33_double_lock_p1_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/34_double_lock_p2_vs_true-unreach-call.c
+++ b/c/pthread-ext/34_double_lock_p2_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/34_double_lock_p2_vs_true-unreach-call.i
+++ b/c/pthread-ext/34_double_lock_p2_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/35_double_lock_p3_vs_true-unreach-call.c
+++ b/c/pthread-ext/35_double_lock_p3_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/35_double_lock_p3_vs_true-unreach-call.i
+++ b/c/pthread-ext/35_double_lock_p3_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/36_stack_cas_p0_vs_concur_true-unreach-call.c
+++ b/c/pthread-ext/36_stack_cas_p0_vs_concur_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //original file: EBStack.java

--- a/c/pthread-ext/36_stack_cas_p0_vs_concur_true-unreach-call.i
+++ b/c/pthread-ext/36_stack_cas_p0_vs_concur_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/37_stack_lock_p0_vs_concur_true-unreach-call.c
+++ b/c/pthread-ext/37_stack_lock_p0_vs_concur_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //original file: EBStack.java

--- a/c/pthread-ext/37_stack_lock_p0_vs_concur_true-unreach-call.i
+++ b/c/pthread-ext/37_stack_lock_p0_vs_concur_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/38_rand_cas_vs_concur_true-unreach-call.c
+++ b/c/pthread-ext/38_rand_cas_vs_concur_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp11234/

--- a/c/pthread-ext/38_rand_cas_vs_concur_true-unreach-call.i
+++ b/c/pthread-ext/38_rand_cas_vs_concur_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/39_rand_lock_p0_vs_true-unreach-call.c
+++ b/c/pthread-ext/39_rand_lock_p0_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp11234/

--- a/c/pthread-ext/39_rand_lock_p0_vs_true-unreach-call.i
+++ b/c/pthread-ext/39_rand_lock_p0_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/40_barrier_vf_false-unreach-call.c
+++ b/c/pthread-ext/40_barrier_vf_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/40_barrier_vf_false-unreach-call.i
+++ b/c/pthread-ext/40_barrier_vf_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/41_FreeBSD__abd_kbd__sliced_true-unreach-call.c
+++ b/c/pthread-ext/41_FreeBSD__abd_kbd__sliced_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/41_FreeBSD__abd_kbd__sliced_true-unreach-call.i
+++ b/c/pthread-ext/41_FreeBSD__abd_kbd__sliced_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.c
+++ b/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.i
+++ b/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/43_NetBSD__sysmon_power__sliced_true-unreach-call.c
+++ b/c/pthread-ext/43_NetBSD__sysmon_power__sliced_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/43_NetBSD__sysmon_power__sliced_true-unreach-call.i
+++ b/c/pthread-ext/43_NetBSD__sysmon_power__sliced_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/44_Solaris__space_map__sliced_true-unreach-call.c
+++ b/c/pthread-ext/44_Solaris__space_map__sliced_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/44_Solaris__space_map__sliced_true-unreach-call.i
+++ b/c/pthread-ext/44_Solaris__space_map__sliced_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/45_monabsex1_vs_true-unreach-call.c
+++ b/c/pthread-ext/45_monabsex1_vs_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/45_monabsex1_vs_true-unreach-call.i
+++ b/c/pthread-ext/45_monabsex1_vs_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/47_ticket_lock_hc_backoff_vs_true-unreach-call.c
+++ b/c/pthread-ext/47_ticket_lock_hc_backoff_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //Ticket lock with proportional backoff

--- a/c/pthread-ext/47_ticket_lock_hc_backoff_vs_true-unreach-call.i
+++ b/c/pthread-ext/47_ticket_lock_hc_backoff_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-ext/48_ticket_lock_low_contention_vs_true-unreach-call.c
+++ b/c/pthread-ext/48_ticket_lock_low_contention_vs_true-unreach-call.c
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/48_ticket_lock_low_contention_vs_true-unreach-call.i
+++ b/c/pthread-ext/48_ticket_lock_low_contention_vs_true-unreach-call.i
@@ -1,3 +1,5 @@
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread-lit/fk2012_true-unreach-call.c
+++ b/c/pthread-lit/fk2012_true-unreach-call.c
@@ -1,3 +1,7 @@
+extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 #include <stdlib.h>
 #include <pthread.h>
 

--- a/c/pthread-lit/fk2012_true-unreach-call.i
+++ b/c/pthread-lit/fk2012_true-unreach-call.i
@@ -1,3 +1,7 @@
+extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
+extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 typedef long unsigned int size_t;
 typedef int wchar_t;
 

--- a/c/pthread/queue_false-unreach-call.c
+++ b/c/pthread/queue_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread/queue_false-unreach-call.i
+++ b/c/pthread/queue_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread/queue_longer_false-unreach-call.c
+++ b/c/pthread/queue_longer_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 #include <pthread.h>
 #include <stdio.h>

--- a/c/pthread/queue_longer_false-unreach-call.i
+++ b/c/pthread/queue_longer_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread/queue_longest_false-unreach-call.c
+++ b/c/pthread/queue_longest_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 #include <pthread.h>
 #include <stdio.h>

--- a/c/pthread/queue_longest_false-unreach-call.i
+++ b/c/pthread/queue_longest_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread/queue_ok_longer_true-unreach-call.c
+++ b/c/pthread/queue_ok_longer_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 #include <pthread.h>
 #include <stdio.h>

--- a/c/pthread/queue_ok_longer_true-unreach-call.i
+++ b/c/pthread/queue_ok_longer_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread/queue_ok_longest_true-unreach-call.c
+++ b/c/pthread/queue_ok_longest_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 #include <pthread.h>
 #include <stdio.h>

--- a/c/pthread/queue_ok_longest_true-unreach-call.i
+++ b/c/pthread/queue_ok_longest_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread/queue_ok_true-unreach-call.c
+++ b/c/pthread/queue_ok_true-unreach-call.c
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread/queue_ok_true-unreach-call.i
+++ b/c/pthread/queue_ok_true-unreach-call.i
@@ -1,3 +1,4 @@
+extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef unsigned char __u_char;

--- a/c/pthread/sigma_false-unreach-call.c
+++ b/c/pthread/sigma_false-unreach-call.c
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <stdlib.h>

--- a/c/pthread/sigma_false-unreach-call.i
+++ b/c/pthread/sigma_false-unreach-call.i
@@ -1,3 +1,4 @@
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 typedef long unsigned int size_t;


### PR DESCRIPTION
This includes functions like:
__VERIFIER_assume, 
__VERIFIER_assert, 
__VERIFIER_error, 
__VERIFIER_nondet_int, 
__VERIFIER_nondet_bool,...

This push request only concerns pthread*/*-programs.
I did not re-create the .i-files, but just added the missing definitions into the first lines.