### PR TITLE
Fixing signatures of routines that are passed to pthread_create

### DIFF
--- a/c/pthread-atomic/qrcu_false-unreach-call.c
+++ b/c/pthread-atomic/qrcu_false-unreach-call.c
@@ -71,7 +71,7 @@ void __VERIFIER_atomic_check_progress2(int readerstart2) {
   return;
 }
 
-void *qrcu_reader1() {
+void *qrcu_reader1(void* arg) {
   int myidx;
   /* rcu_read_lock */
   while (1) {
@@ -93,7 +93,7 @@ void *qrcu_reader1() {
   return 0;
 }
 
-void *qrcu_reader2() {
+void *qrcu_reader2(void* arg) {
   int myidx;
   /* rcu_read_lock */
   while (1) {
@@ -115,7 +115,7 @@ void *qrcu_reader2() {
   return 0;
 }
 
-void* qrcu_updater() {
+void* qrcu_updater(void* arg) {
   int i;
   int readerstart1=__VERIFIER_nondet_int(), readerstart2=__VERIFIER_nondet_int();
   int sum;

--- a/c/pthread-atomic/qrcu_false-unreach-call.i
+++ b/c/pthread-atomic/qrcu_false-unreach-call.i
@@ -667,7 +667,7 @@ void __VERIFIER_atomic_check_progress2(int readerstart2) {
   }
   return;
 }
-void *qrcu_reader1() {
+void *qrcu_reader1(void* arg) {
   int myidx;
   while (1) {
     myidx = idx;
@@ -686,7 +686,7 @@ void *qrcu_reader1() {
   __VERIFIER_atomic_use_done(myidx);
   return 0;
 }
-void *qrcu_reader2() {
+void *qrcu_reader2(void* arg) {
   int myidx;
   while (1) {
     myidx = idx;
@@ -705,7 +705,7 @@ void *qrcu_reader2() {
   __VERIFIER_atomic_use_done(myidx);
   return 0;
 }
-void* qrcu_updater() {
+void* qrcu_updater(void* arg) {
   int i;
   int readerstart1=__VERIFIER_nondet_int(), readerstart2=__VERIFIER_nondet_int();
   int sum;

--- a/c/pthread-atomic/qrcu_true-unreach-call.c
+++ b/c/pthread-atomic/qrcu_true-unreach-call.c
@@ -71,7 +71,7 @@ void __VERIFIER_atomic_check_progress2(int readerstart2) {
   return;
 }
 
-void *qrcu_reader1() {
+void *qrcu_reader1(void* arg) {
   int myidx;
   /* rcu_read_lock */
   while (1) {
@@ -93,7 +93,7 @@ void *qrcu_reader1() {
   return 0;
 }
 
-void *qrcu_reader2() {
+void *qrcu_reader2(void* arg) {
   int myidx;
   /* rcu_read_lock */
   while (1) {
@@ -115,7 +115,7 @@ void *qrcu_reader2() {
   return 0;
 }
 
-void* qrcu_updater() {
+void* qrcu_updater(void* arg) {
   int i;
   int readerstart1, readerstart2;
   int sum;

--- a/c/pthread-atomic/qrcu_true-unreach-call.i
+++ b/c/pthread-atomic/qrcu_true-unreach-call.i
@@ -667,7 +667,7 @@ void __VERIFIER_atomic_check_progress2(int readerstart2) {
   }
   return;
 }
-void *qrcu_reader1() {
+void *qrcu_reader1(void* arg) {
   int myidx;
   while (1) {
     myidx = idx;
@@ -686,7 +686,7 @@ void *qrcu_reader1() {
   __VERIFIER_atomic_use_done(myidx);
   return 0;
 }
-void *qrcu_reader2() {
+void *qrcu_reader2(void* arg) {
   int myidx;
   while (1) {
     myidx = idx;
@@ -705,7 +705,7 @@ void *qrcu_reader2() {
   __VERIFIER_atomic_use_done(myidx);
   return 0;
 }
-void* qrcu_updater() {
+void* qrcu_updater(void* arg) {
   int i;
   int readerstart1, readerstart2;
   int sum;

--- a/c/pthread-atomic/read_write_lock_false-unreach-call.c
+++ b/c/pthread-atomic/read_write_lock_false-unreach-call.c
@@ -24,13 +24,13 @@ void __VERIFIER_atomic_take_read_lock() {
   r = r+1;
 }
 
-void *writer() { //writer
+void *writer(void *arg) { //writer
   __VERIFIER_atomic_take_write_lock();  
   x = 3;
   w = 0;
 }
 
-void *reader() { //reader
+void *reader(void *arg) { //reader
   int l;
   __VERIFIER_atomic_take_read_lock();
   l = x;

--- a/c/pthread-atomic/read_write_lock_false-unreach-call.i
+++ b/c/pthread-atomic/read_write_lock_false-unreach-call.i
@@ -642,12 +642,12 @@ void __VERIFIER_atomic_take_read_lock() {
   __VERIFIER_assume(w==0);
   r = r+1;
 }
-void *writer() {
+void *writer(void *arg) {
   __VERIFIER_atomic_take_write_lock();
   x = 3;
   w = 0;
 }
-void *reader() {
+void *reader(void *arg) {
   int l;
   __VERIFIER_atomic_take_read_lock();
   l = x;

--- a/c/pthread-atomic/read_write_lock_true-unreach-call.c
+++ b/c/pthread-atomic/read_write_lock_true-unreach-call.c
@@ -28,13 +28,13 @@ void __VERIFIER_atomic_release_read_lock() {
   r = r-1;
 }
 
-void *writer() { //writer
+void *writer(void *arg) { //writer
   __VERIFIER_atomic_take_write_lock();  
   x = 3;
   w = 0;
 }
 
-void *reader() { //reader
+void *reader(void *arg) { //reader
   int l;
   __VERIFIER_atomic_take_read_lock();
   l = x;

--- a/c/pthread-atomic/read_write_lock_true-unreach-call.i
+++ b/c/pthread-atomic/read_write_lock_true-unreach-call.i
@@ -645,12 +645,12 @@ void __VERIFIER_atomic_take_read_lock() {
 void __VERIFIER_atomic_release_read_lock() {
   r = r-1;
 }
-void *writer() {
+void *writer(void *arg) {
   __VERIFIER_atomic_take_write_lock();
   x = 3;
   w = 0;
 }
-void *reader() {
+void *reader(void *arg) {
   int l;
   __VERIFIER_atomic_take_read_lock();
   l = x;


### PR DESCRIPTION
Based on my understanding of the spec, these routines should take one void* argument.