### PR TITLE
Fix or comment out bad assembly code that gcc 5.2 rejects with the error

### DIFF
--- a/c/ldv-linux-3.0/usb_urb-drivers-media-video-c-qcam.ko_true-unreach-call.cil.out.i.pp.cil.c
+++ b/c/ldv-linux-3.0/usb_urb-drivers-media-video-c-qcam.ko_true-unreach-call.cil.out.i.pp.cil.c
@@ -6006,7 +6006,7 @@ __inline static struct thread_info *current_thread_info(void)
             goto switch_break;
             case_2: 
 #line 222
-            __asm__  ("mov"
+            /* __asm__  ("mov"
                       "w "
                       "%%"
                       "gs"
@@ -6014,6 +6014,7 @@ __inline static struct thread_info *current_thread_info(void)
                       "%P"
                       "1"
                       ",%0": "=r" (pfo_ret__): "p" (& kernel_stack));
+*/
 #line 222
             goto switch_break;
             case_4: 

--- a/c/ldv-linux-3.0/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.i.pp.cil.c
+++ b/c/ldv-linux-3.0/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.i.pp.cil.c
@@ -5419,7 +5419,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
             goto switch_break;
             case_2: 
 #line 14
-            __asm__  ("mov"
+            /* __asm__  ("mov"
                       "w "
                       "%%"
                       "gs"
@@ -5427,6 +5427,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
                       "%P"
                       "1"
                       ",%0": "=r" (pfo_ret__): "p" (& current_task));
+*/
 #line 14
             goto switch_break;
             case_4: 
@@ -7183,7 +7184,7 @@ int msp_sleep(struct msp_state *state , int timeout )
 #line 306
                 __ptr___0 = (u16 volatile   *)__cil_tmp25;
 #line 306
-                __asm__  volatile   ("xchgw %0,%1": "=r" (__x), "+m" (*__ptr___0): "0" (__x): "memory");
+                __asm__  volatile   ("xchgw %0,%1": "=r" (*((u16*) &__x)), "+m" (*__ptr___0): "0" (*((u16*) &__x)): "memory");
                 }
 #line 306
                 goto switch_break;

--- a/c/ldv-linux-3.0/usb_urb-drivers-usb-misc-iowarrior.ko_false-unreach-call.cil.out.i.pp.cil.c
+++ b/c/ldv-linux-3.0/usb_urb-drivers-usb-misc-iowarrior.ko_false-unreach-call.cil.out.i.pp.cil.c
@@ -4533,6 +4533,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
             goto switch_break;
             case_2: 
 #line 14
+            /*
             __asm__  ("mov"
                       "w "
                       "%%"
@@ -4541,6 +4542,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
                       "%P"
                       "1"
                       ",%0": "=r" (pfo_ret__): "p" (& current_task));
+*/
 #line 14
             goto switch_break;
             case_4: 

--- a/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.i.pp.cil.c
+++ b/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.i.pp.cil.c
@@ -5045,7 +5045,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
             goto switch_break;
             case_2: 
 #line 14
-            __asm__  ("mov"
+            /*__asm__  ("mov"
                       "w "
                       "%%"
                       "gs"
@@ -5053,6 +5053,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
                       "%P"
                       "1"
                       ",%0": "=r" (pfo_ret__): "p" (& current_task));
+*/
 #line 14
             goto switch_break;
             case_4: 

--- a/c/ldv-linux-3.0/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.i.pp.cil.c
+++ b/c/ldv-linux-3.0/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.i.pp.cil.c
@@ -6341,7 +6341,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
             goto switch_break;
             case_2: 
 #line 14
-            __asm__  ("mov"
+            /* __asm__  ("mov"
                       "w "
                       "%%"
                       "gs"
@@ -6349,6 +6349,7 @@ __inline static struct task_struct *( __attribute__((__always_inline__)) get_cur
                       "%P"
                       "1"
                       ",%0": "=r" (pfo_ret__): "p" (& current_task));
+*/
 #line 14
             goto switch_break;
             case_4: 
@@ -6501,7 +6502,7 @@ __inline static struct thread_info *current_thread_info(void)
             goto switch_break;
             case_2: 
 #line 222
-            __asm__  ("mov"
+            /*__asm__  ("mov"
                       "w "
                       "%%"
                       "gs"
@@ -6509,6 +6510,7 @@ __inline static struct thread_info *current_thread_info(void)
                       "%P"
                       "1"
                       ",%0": "=r" (pfo_ret__): "p" (& kernel_stack));
+*/
 #line 222
             goto switch_break;
             case_4: 
@@ -9145,7 +9147,7 @@ static int vhost_worker(void *data )
 #line 194
                 __ptr___0 = (u16 volatile   *)__cil_tmp27;
 #line 194
-                __asm__  volatile   ("xchgw %0,%1": "=r" (__x), "+m" (*__ptr___0): "0" (__x): "memory");
+                __asm__  volatile   ("xchgw %0,%1": "=r" (*((u16*) &__x)), "+m" (*__ptr___0): "0" (*((u16*) &__x)): "memory");
                 }
 #line 194
                 goto switch_break;


### PR DESCRIPTION
```
Error: incorrect register `%rax' used with `w' suffix
```

This only appears when make is run with ``SYNTAX_ONLY=0`` because
when gcc is passed ``-fsyntax-only`` (i.e. ``SYNTAX_ONLY=1``) the
GNU assembler is not invoked.

This fixes issue #42