### PR TITLE
memsafety bugfix in termination-crafted

### DIFF
--- a/c/termination-crafted/LexIndexValue-Pointer_false-valid-deref.c
+++ b/c/termination-crafted/LexIndexValue-Pointer_false-valid-deref.c
@@ -2,7 +2,8 @@
  * Date: 2012-06-03
  * Author: heizmann@informatik.uni-freiburg.de
  *
- * 2-lex ranking function: f(p, q, *q) = (p + 1048 - q, *q)
+ * Original version of LexIndexValue-Pointer_true-termination.c
+ * which has a memsafety bug.
  *
  */
 #include <stdlib.h>
@@ -12,7 +13,7 @@ extern int __VERIFIER_nondet_int(void);
 int main() {
 	int *p = malloc(1048 * sizeof(int));
 	int *q = p;
-	while (q < p + 1048 && *q >= 0) {
+	while (*q >= 0 && q < p + 1048 * sizeof(int)) {
 		if (__VERIFIER_nondet_int()) {
 			q++;
 		} else {


### PR DESCRIPTION
additionally, I added the original copy with a _false-valid-deref label